### PR TITLE
公開メモはpublic_memosテーブルから取得する

### DIFF
--- a/app/src/app.go
+++ b/app/src/app.go
@@ -241,7 +241,7 @@ func topHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	rows.Close()
 
-	rows, err = dbConn.Query("SELECT m.* FROM public_memos as pm inner join memos as m on pm.memo_id = m.id ORDER BY pm.created_at DESC, pm.memo_id DESC LIMIT ?", memosPerPage)
+	rows, err = dbConn.Query("select m.* from memos as m inner join (select memo_id from public_memos order by created_at desc, memo_id desc limit ?) as t on t.memo_id = m.id;", memosPerPage)
 	if err != nil {
 		serverError(w, err)
 		return

--- a/app/src/app.go
+++ b/app/src/app.go
@@ -301,7 +301,7 @@ func recentHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	rows.Close()
 
-	rows, err = dbConn.Query("SELECT m.* FROM public_memos as pm inner join memos as m on pm.memo_id = m.id ORDER BY pm.created_at DESC, pm.memo_id DESC LIMIT ? OFFSET ?", memosPerPage, memosPerPage*page)
+	rows, err = dbConn.Query("select m.* from memos as m inner join (select memo_id from public_memos order by created_at desc, memo_id desc limit ? offset ?) as t on t.memo_id = m.id;", memosPerPage, memosPerPage*page)
 	if err != nil {
 		serverError(w, err)
 		return

--- a/app/src/app.go
+++ b/app/src/app.go
@@ -231,7 +231,7 @@ func topHandler(w http.ResponseWriter, r *http.Request) {
 	user := getUser(w, r, dbConn, session)
 
 	var totalCount int
-	rows, err := dbConn.Query("SELECT count(*) AS c FROM memos WHERE is_private=0")
+	rows, err := dbConn.Query("SELECT count(*) AS c FROM public_memos")
 	if err != nil {
 		serverError(w, err)
 		return
@@ -241,7 +241,7 @@ func topHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	rows.Close()
 
-	rows, err = dbConn.Query("SELECT * FROM memos WHERE is_private=0 ORDER BY created_at DESC, id DESC LIMIT ?", memosPerPage)
+	rows, err = dbConn.Query("SELECT m.* FROM public_memos as pm inner join memos as m on pm.memo_id = m.id ORDER BY pm.created_at DESC, pm.memo_id DESC LIMIT ?", memosPerPage)
 	if err != nil {
 		serverError(w, err)
 		return
@@ -290,7 +290,7 @@ func recentHandler(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	page, _ := strconv.Atoi(vars["page"])
 
-	rows, err := dbConn.Query("SELECT count(*) AS c FROM memos WHERE is_private=0")
+	rows, err := dbConn.Query("SELECT count(*) AS c FROM public_memos")
 	if err != nil {
 		serverError(w, err)
 		return
@@ -301,7 +301,7 @@ func recentHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	rows.Close()
 
-	rows, err = dbConn.Query("SELECT * FROM memos WHERE is_private=0 ORDER BY created_at DESC, id DESC LIMIT ? OFFSET ?", memosPerPage, memosPerPage*page)
+	rows, err = dbConn.Query("SELECT m.* FROM public_memos as pm inner join memos as m on pm.memo_id = m.id ORDER BY pm.created_at DESC, pm.memo_id DESC LIMIT ? OFFSET ?", memosPerPage, memosPerPage*page)
 	if err != nil {
 		serverError(w, err)
 		return


### PR DESCRIPTION
refs #1 

公開メモのみを取得しているケースが多いので、公開メモのみを保持するpublic_memosテーブルを用意した。
そっちを参照するように書き換える。